### PR TITLE
Apply fix on random affiliate for when rand() generates 0, resulting in a -1 in the sql

### DIFF
--- a/enthusiast/mod_owned.php
+++ b/enthusiast/mod_owned.php
@@ -1981,6 +1981,7 @@ function get_listing_stats( $id, $extended = false ) {
 
          // random affiliate
          $rand = rand( 1, $stats['totalaffiliates'] ) - 1;
+         if ($rand < 1) $rand++; // Fix for 0 or negative output
          $query = "SELECT * FROM `$afftable` LIMIT :rand, 1";
          $result = $db_link_list->prepare($query);
          $result->bindParam(':rand', $rand, PDO::PARAM_INT);


### PR DESCRIPTION
Saw some people reporting this error on TFL forums, so I went ahead and applied your [fix from here](https://github.com/Lysianthus/enthusiast/commit/3fb9f6c1e65e9e79630975901f28d61f89837e3c) to this line too.